### PR TITLE
Fix bridge URL in configuration script

### DIFF
--- a/apps/www/src/pages/installation.astro
+++ b/apps/www/src/pages/installation.astro
@@ -105,7 +105,7 @@ import { Content as InstallationContent } from "../content/installation.md";
 
   <!-- Config Generator Form (injected via JS) -->
   <script>
-    const BRIDGE_URL = 'https://bridge.wafir.io';
+    const BRIDGE_URL = 'https://v6hvmahyx2.execute-api.us-east-2.amazonaws.com';
     const sampleJson = `{
   "installationId": 12345678,
   "targets": [


### PR DESCRIPTION
Update the bridge URL in the configuration script to point to the correct API endpoint.