### PR TITLE
Add workflow_dispatch trigger to publish workflow

### DIFF
--- a/.github/workflows/publish-wafir.yaml
+++ b/.github/workflows/publish-wafir.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "wafir@*"
+  workflow_dispatch:
 
 jobs:
   publish-npm:


### PR DESCRIPTION
Allow publish-wafir workflow to be manually dispatched.