### PR TITLE
Don't write project data to issue body

### DIFF
--- a/apps/bridge/src/modules/submit/service.ts
+++ b/apps/bridge/src/modules/submit/service.ts
@@ -50,11 +50,13 @@ export class SubmitService {
    * @param formFields - The form field values keyed by field ID
    * @param fieldOrder - Optional array of field IDs specifying display order
    * @param fieldLabels - Optional map of field IDs to their display labels
+   * @param excludeFields - Optional set of field IDs to exclude (e.g., fields written to project)
    */
   buildMarkdownFromFields(
     formFields: Record<string, unknown>,
     fieldOrder?: string[],
     fieldLabels?: Record<string, string>,
+    excludeFields?: Set<string>,
   ): string {
     const orderedKeys = fieldOrder?.length
       ? fieldOrder.filter((key) => key in formFields)
@@ -64,6 +66,7 @@ export class SubmitService {
 
     for (const key of orderedKeys) {
       if (EXCLUDED_FORM_KEYS.has(key)) continue;
+      if (excludeFields?.has(key)) continue;
 
       const value = formFields[key];
       if (value === undefined || value === null || value === "") continue;

--- a/apps/bridge/test/submit.test.ts
+++ b/apps/bridge/test/submit.test.ts
@@ -1231,6 +1231,11 @@ forms:
         organization: { projectV2: { id: "PVT_abc123" } },
       });
 
+      // Mock fetching project fields (for getMappableFieldIds)
+      mockOctokit.graphql.mockResolvedValueOnce({
+        node: { fields: { nodes: [] } },
+      });
+
       // Mock adding draft to project
       mockOctokit.graphql.mockResolvedValueOnce({
         addProjectV2DraftIssue: {
@@ -1405,6 +1410,11 @@ forms:
         organization: { projectV2: { id: "PVT_both123" } },
       });
 
+      // Mock fetching project fields (for getMappableFieldIds)
+      mockOctokit.graphql.mockResolvedValueOnce({
+        node: { fields: { nodes: [] } },
+      });
+
       // Mock adding issue to project
       mockOctokit.graphql.mockResolvedValueOnce({
         addProjectV2ItemById: {
@@ -1549,6 +1559,11 @@ forms:
         organization: { projectV2: { id: "PVT_multi123" } },
       });
 
+      // Mock fetching project fields (for getMappableFieldIds)
+      mockOctokit.graphql.mockResolvedValueOnce({
+        node: { fields: { nodes: [] } },
+      });
+
       // Mock adding issue to project
       mockOctokit.graphql.mockResolvedValueOnce({
         addProjectV2ItemById: {
@@ -1622,6 +1637,11 @@ forms:
       // Mock finding the project
       mockOctokit.graphql.mockResolvedValueOnce({
         organization: { projectV2: { id: "PVT_all123" } },
+      });
+
+      // Mock fetching project fields (for getMappableFieldIds)
+      mockOctokit.graphql.mockResolvedValueOnce({
+        node: { fields: { nodes: [] } },
       });
 
       // Mock adding issue to project
@@ -1700,6 +1720,11 @@ forms:
         organization: { projectV2: { id: "PVT_empty123" } },
       });
 
+      // Mock fetching project fields (for getMappableFieldIds)
+      mockOctokit.graphql.mockResolvedValueOnce({
+        node: { fields: { nodes: [] } },
+      });
+
       // Mock adding issue to project
       mockOctokit.graphql.mockResolvedValueOnce({
         addProjectV2ItemById: {
@@ -1766,6 +1791,11 @@ forms:
       // Mock finding the project
       mockOctokit.graphql.mockResolvedValueOnce({
         organization: { projectV2: { id: "PVT_proj_only123" } },
+      });
+
+      // Mock fetching project fields (for getMappableFieldIds)
+      mockOctokit.graphql.mockResolvedValueOnce({
+        node: { fields: { nodes: [] } },
       });
 
       // Mock adding draft to project
@@ -1886,6 +1916,11 @@ forms:
       // User project lookup succeeds
       mockOctokit.graphql.mockResolvedValueOnce({
         user: { projectV2: { id: "PVT_user123" } },
+      });
+
+      // Mock fetching project fields (for getMappableFieldIds)
+      mockOctokit.graphql.mockResolvedValueOnce({
+        node: { fields: { nodes: [] } },
       });
 
       // Add draft succeeds

--- a/apps/www/public/wafir.yaml
+++ b/apps/www/public/wafir.yaml
@@ -1,6 +1,4 @@
-# WAFIR Configuration - Wafir GitHub Page
-# Configuration for the Wafir documentation website
-# Use this as a reference for the default behavior.
+# Wafir widget configuration for the public Wafir GitHub Pages site
 
 title: "Contact Us"
 
@@ -13,12 +11,6 @@ targets:
     type: github/project
     target: BPS-Consulting/9
     authRef: "105081464"
-
-# Note: telemetry section is deprecated, use autofill fields instead for user opt-in
-# telemetry:
-#   screenshot: true
-#   browserInfo: true
-#   consoleLog: false
 
 forms:
   - id: feedback
@@ -64,9 +56,35 @@ forms:
         type: textarea
         attributes:
           label: "Additional information:"
+          placeholder: "Please add some details to help us understand your suggestion better"
         validations:
           required: false
-
+      - id: value
+        type: dropdown
+        attributes:
+          label: "Business value"
+          options:
+            - label: "Low"
+              value: "Low"
+            - label: "Medium"
+              value: "Medium"
+            - label: "High"
+              value: "High"
+        validations:
+          required: false
+      - id: needed
+        type: dropdown
+        attributes:
+          label: "Needed"
+          options:
+            - label: "Later"
+              value: "Later"
+            - label: "Soon"
+              value: "Soon"
+            - label: "Now"
+              value: "Now"
+        validations:
+          required: false
   - id: issue
     label: Issue
     icon: bug

--- a/internal/wafir-dev/public/wafir.yaml
+++ b/internal/wafir-dev/public/wafir.yaml
@@ -1,13 +1,7 @@
-# WAFIR Configuration Example - Default
-# This example shows what the widget displays when no forms are specified.
-# Use this as a reference for the default behavior.
-# Host this file anywhere and point your widget to it via configUrl
+# Wafir config for internal testing.  Targets Wafir repo.
 
 title: "Contact Us"
 
-# Targets define where feedback gets sent. 
-# You can have multiple targets and specify which forms send to which targets.  
-# The first target will be used by default.
 targets:
   - id: default
     type: github/issues
@@ -17,12 +11,6 @@ targets:
     type: github/project
     target: BPS-Consulting/9
     authRef: "105081464"
-
-# Note: telemetry section is deprecated, use autofill fields instead for user opt-in
-# telemetry:
-#   screenshot: true
-#   browserInfo: true
-#   consoleLog: false
 
 forms:
   - id: feedback
@@ -58,6 +46,7 @@ forms:
         type: textarea
         attributes:
           label: "Additional information:"
+          placeholder: "Please add some details to help us understand your suggestion better"
         validations:
           required: false
       - id: value
@@ -86,6 +75,7 @@ forms:
               value: "Now"
         validations:
           required: false
+          
   - id: bug
     label: Issue
     icon: bug


### PR DESCRIPTION
Exclude project-mapped fields from the issue body to prevent sensitive project data from being exposed. This change enhances privacy and ensures only relevant information is included in the issue submissions.