### PR TITLE
Add display prop to control field visibility

### DIFF
--- a/apps/bridge/src/shared/schemas/wafir-config.ts
+++ b/apps/bridge/src/shared/schemas/wafir-config.ts
@@ -22,6 +22,13 @@ const fieldSchema = {
       description:
         "Unique identifier for the field (used as key in JSON output/issue body).",
     },
+    display: {
+      type: "string",
+      enum: ["visible", "none"],
+      default: "visible",
+      description:
+        "Controls field visibility. 'none' hides the field from the UI but still includes its value in submissions. Defaults to 'visible'.",
+    },
     attributes: {
       type: "object",
       description: "Visual and behavioral attributes for the field.",

--- a/apps/bridge/src/shared/utils/config-validator.ts
+++ b/apps/bridge/src/shared/utils/config-validator.ts
@@ -118,6 +118,7 @@ const DEFAULT_CONFIG: WafirConfig = {
 interface FieldConfig {
   type: string;
   id?: string;
+  display?: "visible" | "none";
   attributes?: {
     label?: string;
     options?: string[] | Array<{ label: string; required?: boolean }>;

--- a/apps/bridge/swagger.json
+++ b/apps/bridge/swagger.json
@@ -295,6 +295,15 @@
                                   "type": "string",
                                   "description": "Unique identifier for the field (used as key in JSON output/issue body)."
                                 },
+                                "display": {
+                                  "type": "string",
+                                  "enum": [
+                                    "visible",
+                                    "none"
+                                  ],
+                                  "default": "visible",
+                                  "description": "Controls field visibility. 'none' hides the field from the UI but still includes its value in submissions. Defaults to 'visible'."
+                                },
                                 "attributes": {
                                   "type": "object",
                                   "description": "Visual and behavioral attributes for the field.",

--- a/apps/www/src/content/documentation.md
+++ b/apps/www/src/content/documentation.md
@@ -214,6 +214,7 @@ Each field is defined using `id`, `type`, `attributes`, and `validations` subkey
 | ------------ | ------------ | ------------ | -------------------------------------------------------- |
 | id           | field (root) | string       | Unique identifier for the field                          |
 | type         | field (root) | string       | Field input type (see above)                             |
+| display      | field (root) | string?      | Field visibility: `visible` (default) or `none` (hidden) |
 | attributes   | field (root) | object       | Display and options attributes                           |
 | validations  | field (root) | object       | Validation rules (e.g., required: true/false)            |
 | label        | attributes   | string       | Display label                                            |

--- a/internal/wafir-dev/public/wafir.yaml
+++ b/internal/wafir-dev/public/wafir.yaml
@@ -30,6 +30,13 @@ forms:
           label: "What is the main reason for this rating?"
         validations:
           required: false
+      - id: submitted
+        type: date
+        display: none
+        attributes:
+          value: "today"
+        validations:
+          required: true
 
   - id: feature
     label: Suggestion

--- a/packages/wafir/src/api/client.ts
+++ b/packages/wafir/src/api/client.ts
@@ -19,8 +19,24 @@ const getClient = () => {
 export type WafirConfigBase =
   paths["/config/"]["get"]["responses"][200]["content"]["application/json"];
 
+// Canonical form and field types from API schema
+// Make display optional since it has a default value of "visible"
+type FieldConfigApiBase = NonNullable<
+  NonNullable<WafirConfigBase["forms"]>[number]["body"]
+>[number];
+export type FieldConfigApi = Omit<FieldConfigApiBase, "display"> & {
+  display?: FieldConfigApiBase["display"];
+};
+
+// FormConfigApi with body using the corrected FieldConfigApi type
+type FormConfigApiBase = NonNullable<WafirConfigBase["forms"]>[number];
+export type FormConfigApi = Omit<FormConfigApiBase, "body"> & {
+  body?: FieldConfigApi[];
+};
+
 // Extended WafirConfig type with targets array (required for user-hosted configs)
-export type WafirConfig = WafirConfigBase & {
+// and corrected forms array type
+export type WafirConfig = Omit<WafirConfigBase, "forms"> & {
   targets: Array<{
     /** Unique identifier for this target, referenced by forms to route submissions. */
     id: string;
@@ -31,11 +47,8 @@ export type WafirConfig = WafirConfigBase & {
     /** Authentication reference used to authorize communication with the target. For GitHub types, this is the installation ID. */
     authRef: string;
   }>;
+  forms?: FormConfigApi[];
 };
-
-// Canonical form and field types from API schema
-export type FormConfigApi = NonNullable<WafirConfig["forms"]>[number];
-export type FieldConfigApi = NonNullable<FormConfigApi["body"]>[number];
 
 export const checkBridgeHealth = async (
   bridgeUrl?: string,

--- a/packages/wafir/src/api/index.ts
+++ b/packages/wafir/src/api/index.ts
@@ -256,6 +256,12 @@ export interface paths {
                                     type: "input" | "email" | "textarea" | "dropdown" | "checkboxes" | "markdown" | "rating" | "date";
                                     /** @description Unique identifier for the field (used as key in JSON output/issue body). */
                                     id?: string;
+                                    /**
+                                     * @description Controls field visibility. 'none' hides the field from the UI but still includes its value in submissions. Defaults to 'visible'.
+                                     * @default visible
+                                     * @enum {string}
+                                     */
+                                    display: "visible" | "none";
                                     /** @description Visual and behavioral attributes for the field. */
                                     attributes?: {
                                         /** @description Display label for the field. */

--- a/packages/wafir/src/wafir-form.ts
+++ b/packages/wafir/src/wafir-form.ts
@@ -518,6 +518,10 @@ export class WafirForm extends LitElement {
           ? html`<h2 class="form-title">${this.formLabel}</h2>`
           : ""}
         ${this.fields.map((field) => {
+          // Skip rendering fields with display: none (value still submitted via willUpdate initialization)
+          if ((field as any).display === "none") {
+            return null;
+          }
           if (field.type === "checkboxes")
             return html`<div class="form-group">
               ${this._renderFieldInput(field)}


### PR DESCRIPTION
Introduce a `display` property to fields, allowing control over their visibility in the UI. This property can be set to "visible" or "none", with "none" hiding the field while still including its value in submissions. Updates to the relevant types and documentation reflect this new functionality.