### PR TITLE
Add info-only forms

### DIFF
--- a/apps/www/public/wafir.yaml
+++ b/apps/www/public/wafir.yaml
@@ -120,3 +120,12 @@ forms:
           autofill: screenshot
         validations:
           required: false
+
+  - id: question
+    label: ❓Question
+    targets: [none]
+    body:
+      - id: info
+        type: markdown
+        attributes:
+          value: "Please ask your question in our GitHub Discussions forum: https://github.com/BPS-Consulting/wafir/discussions"

--- a/apps/www/src/content/documentation.md
+++ b/apps/www/src/content/documentation.md
@@ -112,7 +112,7 @@ Forms define the structure of your feedback widget. Each form represents a disti
 | `icon`        | string?   | Icon name: `bug`, `lightbulb`, or `thumbsup`                             |
 | `labels`      | string[]? | GitHub labels to auto-apply to issues                                    |
 | `templateUrl` | string?   | URL to a GitHub issue form template YAML                                 |
-| `targets`     | array?    | Array of target IDs to route submissions to                              |
+| `targets`     | array?    | Array of target IDs to route submissions to. Set to a non-existent ID (e.g., `[none]`) to disable the submit button for informational forms. |
 | `body`        | array     | Array of field definitions                                               |
 
 ### Example

--- a/internal/wafir-dev/public/wafir.yaml
+++ b/internal/wafir-dev/public/wafir.yaml
@@ -122,3 +122,12 @@ forms:
           autofill: screenshot
         validations:
           required: false
+
+  - id: question
+    label: ❓Question
+    targets: [none]
+    body:
+      - id: info
+        type: markdown
+        attributes:
+          value: "Please ask your question in our GitHub Discussions forum: https://github.com/BPS-Consulting/wafir/discussions"

--- a/packages/wafir/src/wafir-form.ts
+++ b/packages/wafir/src/wafir-form.ts
@@ -47,6 +47,9 @@ export class WafirForm extends LitElement {
   @property({ type: Boolean })
   bridgeAvailable = true;
 
+  @property({ type: Boolean })
+  hasValidTarget = true;
+
   private _formDataController = new StoreController(this, formData);
   private _browserInfoController = new StoreController(this, browserInfo);
   private _consoleLogsController = new StoreController(this, consoleLogs);
@@ -572,7 +575,7 @@ export class WafirForm extends LitElement {
         <button
           class="submit-button"
           type="submit"
-          ?disabled="${this.loading || !this.bridgeAvailable}"
+          ?disabled="${this.loading || !this.bridgeAvailable || !this.hasValidTarget}"
         >
           ${this.loading
             ? html`<span class="spinner"></span> Submitting...`

--- a/packages/wafir/src/wafir-widget.ts
+++ b/packages/wafir/src/wafir-widget.ts
@@ -463,6 +463,7 @@ export class WafirWidget extends LitElement {
         id: form.id,
         label: form.label || this._capitalize(form.id),
         icon: form.icon,
+        targets: form.targets,
         body:
           form.body && form.body.length > 0
             ? form.body
@@ -500,6 +501,18 @@ export class WafirWidget extends LitElement {
 
   private _switchForm(formId: string) {
     this._activeFormId = formId;
+  }
+
+  private _formHasValidTarget(): boolean {
+    if (!this._config?.targets?.length) return false;
+    const activeForm = this._getActiveForm();
+    const formTargets = activeForm?.targets;
+    if (formTargets?.length) {
+      return formTargets.some((id) =>
+        this._config!.targets.some((t) => t.id === id),
+      );
+    }
+    return true;
   }
 
   @property({ type: String, attribute: "config-url" })
@@ -728,6 +741,7 @@ export class WafirWidget extends LitElement {
                   .tabId="${this._activeFormId}"
                   .fields="${this._getActiveFormConfig()}"
                   .formLabel="${this._getActiveForm()?.label || ""}"
+                  .hasValidTarget="${this._formHasValidTarget()}"
                   @form-submit="${this._handleSubmit}"
                 ></wafir-form>
                 ${this.isConfigLoading


### PR DESCRIPTION
Support info only forms by disabling the submit button when the form target is not a valid target (e.g., 'none').